### PR TITLE
Offset spines in `adjust_spines by` default 

### DIFF
--- a/niceplots/utils.py
+++ b/niceplots/utils.py
@@ -83,7 +83,7 @@ def handle_close(evt):
     plt.savefig("figure.pdf")
 
 
-def adjust_spines(ax=None, spines=["left", "bottom"], outward=False):
+def adjust_spines(ax=None, spines=["left", "bottom"], outward=True):
     """Function to shift the axes/spines so they have that offset
     Doumont look."""
     if ax is None:

--- a/niceplots/utils.py
+++ b/niceplots/utils.py
@@ -78,7 +78,7 @@ def get_delftColors():
 
 
 def handle_close(evt):
-    """ Handler function that saves the figure as a pdf if the window is closed. """
+    """Handler function that saves the figure as a pdf if the window is closed."""
     plt.tight_layout()
     plt.savefig("figure.pdf")
 
@@ -118,7 +118,7 @@ def adjust_spines(ax=None, spines=["left", "bottom"], outward=True):
 
 
 def draggable_legend(axis=None, color_on=True):
-    """ Function to create draggable labels on a plot. """
+    """Function to create draggable labels on a plot."""
     if axis is None:
         axis = plt.gca()
 
@@ -345,7 +345,7 @@ def stacked_plots(
 
 
 def all():
-    """ Runs all of the functions provided in this module. """
+    """Runs all of the functions provided in this module."""
     adjust_spines()
     draggable_legend()
     plt.gcf().canvas.mpl_connect("close_event", handle_close)


### PR DESCRIPTION
## Purpose
Dunno about the rest of you, but I personally always want to offset the spines when I call `adjust_spines` so I think we should change this to occurring by default, rather than having to specify `outward=True`.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
