### PR TITLE
Add option to specific colormap norm in plotColoredLine

### DIFF
--- a/examples/plot_colored_line.py
+++ b/examples/plot_colored_line.py
@@ -41,7 +41,7 @@ fig.savefig("coloredLine.pdf")
 
 # Use a custom norm to specify the colormap range
 divnorm = TwoSlopeNorm(vmin=-1.0, vcenter=0.8, vmax=1.0)
-fig, ax = niceplots.plotColoredLine(x, y, c, cmap="coolwarm", norm=divnorm, addColorBar=False, cRange=None, cBarLabel="$dy/dx$")
+fig, ax = niceplots.plotColoredLine(x, y, c, cmap="coolwarm", norm=divnorm, addColorBar=False, cBarLabel="$dy/dx$")
 niceplots.adjust_spines(ax)
 ax.set_xlabel("$x$")
 ax.set_ylabel("$y$", rotation="horizontal", ha="right")

--- a/examples/plot_colored_line.py
+++ b/examples/plot_colored_line.py
@@ -14,6 +14,7 @@ colored by their derivatives
 # ==============================================================================
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib.colors import TwoSlopeNorm
 import niceplots
 
 # ==============================================================================
@@ -37,4 +38,16 @@ ax.set_xticklabels([0, r"$\frac{\pi}{2}$", r"$\pi$", r"$\frac{3\pi}{2}$", r"$2\p
 ax.set_xlim(0, 2 * np.pi)
 fig.savefig("coloredLine.png", dpi=400)
 fig.savefig("coloredLine.pdf")
+
+# Use a custom norm to specify the colormap range
+divnorm = TwoSlopeNorm(vmin=-1., vcenter=0.8, vmax=1.)
+fig, ax = niceplots.plotColoredLine(x, y, c, cmap="coolwarm", norm=divnorm)
+niceplots.adjust_spines(ax)
+ax.set_xlabel("$x$")
+ax.set_ylabel("$y$", rotation="horizontal", ha="right")
+ax.set_xticks(np.linspace(0, 2, 5) * np.pi)
+ax.set_xticklabels([0, r"$\frac{\pi}{2}$", r"$\pi$", r"$\frac{3\pi}{2}$", r"$2\pi$"])
+ax.set_xlim(0, 2 * np.pi)
+fig.savefig("coloredLineCustomNorm.png", dpi=400)
+fig.savefig("coloredLineCustomNorm.pdf")
 # plt.show()

--- a/examples/plot_colored_line.py
+++ b/examples/plot_colored_line.py
@@ -29,7 +29,7 @@ c = np.cos(x)
 
 fig, ax = plt.subplots()
 niceplots.plotColoredLine(x, y, c, cmap="coolwarm", fig=fig, ax=ax, addColorBar=True, cRange=None, cBarLabel="$dy/dx$")
-niceplots.plotColoredLine(x, c, -y, cmap="coolwarm", fig=fig, ax=ax, addColorBar=True, cRange=None, cBarLabel="$dy/dx$")
+niceplots.plotColoredLine(x, c, -y, cmap="coolwarm", fig=fig, ax=ax)
 niceplots.adjust_spines(ax)
 ax.set_xlabel("$x$")
 ax.set_ylabel("$y$", rotation="horizontal", ha="right")
@@ -41,7 +41,7 @@ fig.savefig("coloredLine.pdf")
 
 # Use a custom norm to specify the colormap range
 divnorm = TwoSlopeNorm(vmin=-1.0, vcenter=0.8, vmax=1.0)
-fig, ax = niceplots.plotColoredLine(x, y, c, cmap="coolwarm", norm=divnorm)
+fig, ax = niceplots.plotColoredLine(x, y, c, cmap="coolwarm", norm=divnorm, addColorBar=False, cRange=None, cBarLabel="$dy/dx$")
 niceplots.adjust_spines(ax)
 ax.set_xlabel("$x$")
 ax.set_ylabel("$y$", rotation="horizontal", ha="right")

--- a/examples/plot_colored_line.py
+++ b/examples/plot_colored_line.py
@@ -40,7 +40,7 @@ fig.savefig("coloredLine.png", dpi=400)
 fig.savefig("coloredLine.pdf")
 
 # Use a custom norm to specify the colormap range
-divnorm = TwoSlopeNorm(vmin=-1., vcenter=0.8, vmax=1.)
+divnorm = TwoSlopeNorm(vmin=-1.0, vcenter=0.8, vmax=1.0)
 fig, ax = niceplots.plotColoredLine(x, y, c, cmap="coolwarm", norm=divnorm)
 niceplots.adjust_spines(ax)
 ax.set_xlabel("$x$")

--- a/niceplots/utils.py
+++ b/niceplots/utils.py
@@ -546,7 +546,7 @@ def plotOptProb(
         return
 
 
-def plotColoredLine(x, y, c, cmap=None, fig=None, ax=None, addColorBar=False, cRange=None, cBarLabel=None, **kwargs):
+def plotColoredLine(x, y, c, cmap=None, fig=None, ax=None, addColorBar=False, cRange=None, cBarLabel=None, norm=None, **kwargs):
     """Plot an XY line whose color is determined by some other variable C
 
     Parameters
@@ -569,6 +569,8 @@ def plotColoredLine(x, y, c, cmap=None, fig=None, ax=None, addColorBar=False, cR
         Upper and lower limit for the colormap, by default None, in which case the min and max values of c are used.
     cBarLabel : str, optional
         Label for the colormap, by default None
+    norm : matplotlib.colors.Normalize, optional
+        Specify colormap mapping; both this and cRange cannot be specified, it must be one or the other (or neither)
 
     Returns
     -------
@@ -598,10 +600,10 @@ def plotColoredLine(x, y, c, cmap=None, fig=None, ax=None, addColorBar=False, cR
     points = np.array([data["x"], data["y"]]).T.reshape(-1, 1, 2)
     segments = np.concatenate([points[:-1], points[1:]], axis=1)
 
+    if cRange is not None and norm is not None:
+        raise ValueError("cRange and norm cannot both be specified")
     if cRange is not None:
         norm = plt.Normalize(cRange[0], cRange[1])
-    else:
-        norm = None
     lc = LineCollection(segments, cmap=cmap, norm=norm, **kwargs)
 
     # Set the values used for colormapping

--- a/niceplots/utils.py
+++ b/niceplots/utils.py
@@ -576,10 +576,10 @@ def plotColoredLine(
 
     Returns
     -------
-    ax : matplotlib axes object
-        Axis with the colored line. Returned only if no input ax object is specified
     fig : matplotlib figure object
         Figure containing the plot. Returned only if no input ax object is specified
+    ax : matplotlib axes object
+        Axis with the colored line. Returned only if no input ax object is specified
     """
     returnFig = False
     if ax is None or fig is None:

--- a/niceplots/utils.py
+++ b/niceplots/utils.py
@@ -546,7 +546,9 @@ def plotOptProb(
         return
 
 
-def plotColoredLine(x, y, c, cmap=None, fig=None, ax=None, addColorBar=False, cRange=None, cBarLabel=None, norm=None, **kwargs):
+def plotColoredLine(
+    x, y, c, cmap=None, fig=None, ax=None, addColorBar=False, cRange=None, cBarLabel=None, norm=None, **kwargs
+):
     """Plot an XY line whose color is determined by some other variable C
 
     Parameters


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
Add the ability to specify the colormap norm for the niceplots feature to plot a line with a color from other data. This is useful for diverging colormaps to be able to manually specify the center, min, and max with something like `matplotlib.colors.TwoSlopeNorm`.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
ASAP as possible

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
