### PR TITLE
Improve default behaviour of `label_line_ends`

### DIFF
--- a/niceplots/__init__.py
+++ b/niceplots/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.4.1"
+__version__ = "2.5.0"
 
 from .utils import *
 from .parula import *

--- a/niceplots/utils.py
+++ b/niceplots/utils.py
@@ -280,7 +280,7 @@ def label_line_ends(ax, lines=None, labels=None, colors=None, x_offset_pts=6, y_
         The annotations created
     """
 
-    # By default label all lines in the plot whose labels don't begin with an underscore
+    # By default label all lines in the plot
     if lines is None:
         lines = ax.get_lines()
 

--- a/niceplots/utils.py
+++ b/niceplots/utils.py
@@ -282,7 +282,7 @@ def label_line_ends(ax, lines=None, labels=None, colors=None, x_offset_pts=6, y_
 
     # By default label all lines in the plot whose labels don't begin with an underscore
     if lines is None:
-        lines = [line for line in ax.get_lines()]
+        lines = ax.get_lines()
 
     if labels is None:
         # If we're not given labels, use the lines' label attributes, but ignore any lines that are still using the

--- a/niceplots/utils.py
+++ b/niceplots/utils.py
@@ -260,7 +260,7 @@ def label_line_ends(ax, lines=None, labels=None, colors=None, x_offset_pts=6, y_
     ax : Matplotlib axes
         axes to label the lines of
     lines : iterable of matplotlib line objects, optional
-        Lines to label, by default all lines in the axes whose labels don't begin with an underscore
+        Lines to label, by default all lines in the axes
     labels : list of strings, optional
         Labels for each line, by default uses each line's label attribute
     colors : single or list of colors, optional
@@ -279,13 +279,17 @@ def label_line_ends(ax, lines=None, labels=None, colors=None, x_offset_pts=6, y_
     list of matplotlib annotation objects
         The annotations created
     """
+
     # By default label all lines in the plot whose labels don't begin with an underscore
     if lines is None:
-        lines = [line for line in ax.get_lines() if line.get_label()[0] != "_"]
+        lines = [line for line in ax.get_lines()]
 
     if labels is None:
+        # If we're not given labels, use the liness label attribute, but ignore any lines that are still using the
+        # matplotlib default label which starts with an underscore
+        lines = [line for line in lines if not line.get_label().startswith("_")]
         labels = [line.get_label() for line in lines]
-    
+
     numLines = len(lines)
     if len(labels) != numLines:
         raise ValueError(f"Number of labels ({len(labels)}) doesn't match number of lines ({numLines})")

--- a/niceplots/utils.py
+++ b/niceplots/utils.py
@@ -260,7 +260,7 @@ def label_line_ends(ax, lines=None, labels=None, colors=None, x_offset_pts=6, y_
     ax : Matplotlib axes
         axes to label the lines of
     lines : iterable of matplotlib line objects, optional
-        Lines to label, by default all lines in the axes
+        Lines to label, by default all lines in the axes whose labels don't begin with an underscore
     labels : list of strings, optional
         Labels for each line, by default uses each line's label attribute
     colors : single or list of colors, optional
@@ -279,11 +279,13 @@ def label_line_ends(ax, lines=None, labels=None, colors=None, x_offset_pts=6, y_
     list of matplotlib annotation objects
         The annotations created
     """
+    # By default label all lines in the plot whose labels don't begin with an underscore
     if lines is None:
-        lines = ax.get_lines()
+        lines = [line for line in ax.get_lines() if line.get_label()[0] != "_"]
 
     if labels is None:
         labels = [line.get_label() for line in lines]
+    
     numLines = len(lines)
     if len(labels) != numLines:
         raise ValueError(f"Number of labels ({len(labels)}) doesn't match number of lines ({numLines})")

--- a/niceplots/utils.py
+++ b/niceplots/utils.py
@@ -285,7 +285,7 @@ def label_line_ends(ax, lines=None, labels=None, colors=None, x_offset_pts=6, y_
         lines = [line for line in ax.get_lines()]
 
     if labels is None:
-        # If we're not given labels, use the liness label attribute, but ignore any lines that are still using the
+        # If we're not given labels, use the lines' label attributes, but ignore any lines that are still using the
         # matplotlib default label which starts with an underscore
         lines = [line for line in lines if not line.get_label().startswith("_")]
         labels = [line.get_label() for line in lines]


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->

Modifies the behaviour so that if no labels are passed to `label_line_ends` it will only add labels to lines whose labels don't begin with an underscore. This means `label_line_ends` will avoid labeling lines that don't have useful labels since matplotlib gives all lines default labels that start with underscores (e.g `"_child0"`).

### Example

Previous behaviour:
![image](https://github.com/mdolab/niceplots/assets/20371123/784eec37-33a6-4f56-a702-24ce254ab11e)


New behaviour:
![image](https://github.com/mdolab/niceplots/assets/20371123/34978a6d-b239-4962-8c59-b693eb133377)


## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->

1 day

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
