### PR TITLE
Fix `label_line_ends` behaviour when lines go past right xlim

### DIFF
--- a/niceplots/utils.py
+++ b/niceplots/utils.py
@@ -311,16 +311,46 @@ def label_line_ends(ax, lines=None, labels=None, colors=None, x_offset_pts=6, y_
         pointsInXLimits = np.logical_and(xData >= xlim[0], xData <= xlim[1])
         pointsInYLimits = np.logical_and(yData >= ylim[0], yData <= ylim[1])
         pointsInLimits = np.logical_and(pointsInXLimits, pointsInYLimits)
-        xData = xData[pointsInLimits]
-        yData = yData[pointsInLimits]
 
-        maxXIndex = np.argmax(xData)
-        x = xData[maxXIndex]
-        y = yData[maxXIndex]
+        # If the entre line is outside the axis limits, skip it
+        if not np.any(pointsInLimits):
+            continue
+        elif pointsInLimits[-1]:
+            # If the last point is within the limits, use that one
+            labelCoord = (xData[-1], yData[-1])
+        else:
+            # If the last point is outside the limits, but part of the line is within the limits, put the label at the
+            # point where the line intersects the limits
+
+            # get the index of the last point within the limits
+            lastIndex = np.where(pointsInLimits)[0][-1]
+            # get the x and y coordinates of the last point within the limits and the first point outside the limits
+            innerPoint = np.array([xData[lastIndex], yData[lastIndex]])
+            outerPoint = np.array([xData[lastIndex + 1], yData[lastIndex + 1]])
+
+            # Find the intersection point with the x and y limits as a fraction of the line segment, need to check upper
+            # and lower limits
+            if not pointsInXLimits[lastIndex + 1]:
+                if outerPoint[0] > innerPoint[0]:
+                    xIntersect = (xlim[1] - innerPoint[0]) / (outerPoint[0] - innerPoint[0])
+                else:
+                    xIntersect = (xlim[0] - innerPoint[0]) / (outerPoint[0] - innerPoint[0])
+            else:
+                xIntersect = np.inf
+            if not pointsInYLimits[lastIndex + 1]:
+                if outerPoint[1] > innerPoint[1]:
+                    yIntersect = (ylim[1] - innerPoint[1]) / (outerPoint[1] - innerPoint[1])
+                else:
+                    yIntersect = (ylim[0] - innerPoint[1]) / (outerPoint[1] - innerPoint[1])
+            else:
+                yIntersect = np.inf
+
+            # Place label at the first intersection
+            labelCoord = innerPoint + (outerPoint - innerPoint) * min(xIntersect, yIntersect)
 
         annote = ax.annotate(
             label,
-            xy=(x, y),
+            xy=labelCoord,
             xytext=(x_offset_pts, y_offset_pts),
             color=color,
             textcoords="offset points",

--- a/niceplots/utils.py
+++ b/niceplots/utils.py
@@ -303,16 +303,22 @@ def label_line_ends(ax, lines=None, labels=None, colors=None, x_offset_pts=6, y_
     annotations = []
 
     for line, label, color in zip(lines, labels, colors):
-        # Get the x, y coordinates of the right-most point on the line, or the right xlim of the axes if that is lower
+        # Get the x, y coordinates of the right-most point on the line that is within the axis limits
         xData = line.get_xdata()
         yData = line.get_ydata()
+        xlim = ax.get_xlim()
+        ylim = ax.get_ylim()
+
+        pointsInXLimits = np.logical_and(xData >= xlim[0], xData <= xlim[1])
+        pointsInYLimits = np.logical_and(yData >= ylim[0], yData <= ylim[1])
+        pointsInLimits = np.logical_and(pointsInXLimits, pointsInYLimits)
+        xData = xData[pointsInLimits]
+        yData = yData[pointsInLimits]
+
         maxXIndex = np.argmax(xData)
         x = xData[maxXIndex]
         y = yData[maxXIndex]
-        rightXlim = ax.get_xlim()[1]
-        if x > rightXlim:
-            x = rightXlim
-            y = yData[np.argmax(xData >= x)]
+
         annote = ax.annotate(
             label,
             xy=(x, y),

--- a/niceplots/utils.py
+++ b/niceplots/utils.py
@@ -250,9 +250,8 @@ def draggable_legend(axis=None, color_on=True, **kwargs):
 def label_line_ends(ax, lines=None, labels=None, colors=None, x_offset_pts=6, y_offset_pts=0, **kwargs):
     """Place a label just to the right of each line in the axes
 
-    Note: Because the labels are placed outside of the axes, this function works best for plots where all lines end as
-    close to the right edge of the axes as possible. Additionally you need to either use constrained_layout=True
-    (as NicePlots styles do), or call plt.tight_layout() after calling this function.
+    Note: If any of the lines you are labelling go beyond the axis limits, make sure to call this function after setting
+    the axis limits, otherwise the labels will not be placed correctly
 
     Parameters
     ----------

--- a/niceplots/utils.py
+++ b/niceplots/utils.py
@@ -303,10 +303,16 @@ def label_line_ends(ax, lines=None, labels=None, colors=None, x_offset_pts=6, y_
     annotations = []
 
     for line, label, color in zip(lines, labels, colors):
-        # Get the x, y coordinates of the right-most point on the line
-        maxXIndex = np.argmax(line.get_xdata())
-        x = line.get_xdata()[maxXIndex]
-        y = line.get_ydata()[maxXIndex]
+        # Get the x, y coordinates of the right-most point on the line, or the right xlim of the axes if that is lower
+        xData = line.get_xdata()
+        yData = line.get_ydata()
+        maxXIndex = np.argmax(xData)
+        x = xData[maxXIndex]
+        y = yData[maxXIndex]
+        rightXlim = ax.get_xlim()[1]
+        if x > rightXlim:
+            x = rightXlim
+            y = yData[np.argmax(xData >= x)]
         annote = ax.annotate(
             label,
             xy=(x, y),


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
The `label_line_ends` function puts the label at the point on the line with the largest x coordinate, but if this point is outside the axis limits then the label will be hidden. This PR changes `label_line_ends` to account for the x and y axis limits

Previously:
![image](https://github.com/user-attachments/assets/d94bec8d-abd3-4e7c-ac30-3d9af6550be4)

With this fix:
![image](https://github.com/user-attachments/assets/385e34ce-4bc5-4d76-96f1-83bade8cd7a7)


## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
Soon, but no rush

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
